### PR TITLE
Fix two's complement when reading raw data

### DIFF
--- a/python/PyRedPitaya-1.0/PyRedPitaya/instrument.py
+++ b/python/PyRedPitaya-1.0/PyRedPitaya/instrument.py
@@ -224,7 +224,7 @@ class Scope(MemoryInterface):
         x = self.reads(addr, self.data_length)
         y = x.copy()
         y.dtype = np.int32
-        y[y>2**13] -= 2**14
+        y[y>=2**13] -= 2**14
         return y
         
     @property


### PR DESCRIPTION
`2**13` should also be converted to a negative number since it's sign bit is `1`.
This fixes the results for waveforms with negative saturation.
Tested with a signal generator.
